### PR TITLE
Add "Permission dismissed" case in Chrome

### DIFF
--- a/lib/requestMediaPermissions.js
+++ b/lib/requestMediaPermissions.js
@@ -42,7 +42,7 @@ const requestMediaPermissions = (constraints) => {
                         errorType =
                             MediaPermissionsErrorType.SystemPermissionDenied;
                     }
-                    else if (errMessage === 'Permission denied') {
+                    else if (errMessage === 'Permission denied' || errMessage === 'Permission dismissed') {
                         errorType =
                             MediaPermissionsErrorType.UserPermissionDenied;
                     }


### PR DESCRIPTION
Chrome has one more possible state - if you just dismiss the dialog (eg. by clicking "X" button in the upper right corner). Currently this case returns `MediaPermissionsErrorType.Generic`. It's more precise to return `MediaPermissionsErrorType.UserPermissionDenied`

![image](https://user-images.githubusercontent.com/6008904/215814286-e134b307-6e28-40ba-8264-d53e5a76b590.png)

